### PR TITLE
Specifiers

### DIFF
--- a/include/tori/core/box.hpp
+++ b/include/tori/core/box.hpp
@@ -81,7 +81,7 @@ namespace TORI_NS::detail {
 
       /// value type
       using value_type = T;
-      /// specifier
+      /// term
       static constexpr auto term = inherit_box_term<T>();
 
       /// info table initializer

--- a/include/tori/core/box.hpp
+++ b/include/tori/core/box.hpp
@@ -6,6 +6,9 @@
 #include "object_ptr.hpp"
 #include "type_value.hpp" // clang requires definition of TypeValue to compile.
 
+#include "specifiers.hpp"
+#include "terms.hpp"
+
 #include <cassert>
 
 namespace TORI_NS::detail {
@@ -58,9 +61,9 @@ namespace TORI_NS::detail {
     }
   }
 
-  /// allow custom term from parameter type
+  /// inherit custom term from parameter type
   template <class T>
-  constexpr auto get_value_object_term()
+  constexpr auto inherit_box_term()
   {
     if constexpr (has_term<T>())
       return T::term;
@@ -78,8 +81,8 @@ namespace TORI_NS::detail {
 
       /// value type
       using value_type = T;
-      /// term
-      static constexpr auto term = get_value_object_term<T>();
+      /// specifier
+      static constexpr auto term = inherit_box_term<T>();
 
       /// info table initializer
       struct info_table_initializer

--- a/include/tori/core/eval.hpp
+++ b/include/tori/core/eval.hpp
@@ -166,7 +166,8 @@ namespace TORI_NS::detail {
         // we convert it to closure<...> which is essentially equal to to
         // Object. Type variables are also undecidable so we just convert
         // them to Object.
-        using To = std::add_const_t<typename decltype(guess_object_type(type))::type>;
+        using To =
+          std::add_const_t<typename decltype(guess_object_type(type))::type>;
         // cast to resutn type
         return static_object_cast<To>(result);
       } else {

--- a/include/tori/core/fix.hpp
+++ b/include/tori/core/fix.hpp
@@ -21,7 +21,7 @@ namespace TORI_NS::detail {
 
   struct FixValue
   {
-    // overwrite value term
+    /// overwrite term
     static constexpr auto term = type_c<tm_fix<Fix>>;
   };
 

--- a/include/tori/core/function.hpp
+++ b/include/tori/core/function.hpp
@@ -201,20 +201,13 @@ namespace TORI_NS::detail {
     template <class T, class... Ts>
     struct Function : ClosureN<sizeof...(Ts) - 1>
     {
-      /// specifier
-      static constexpr auto specifier =
-        normalize_specifier(type_c<closure<Ts...>>);
-
       static_assert(
         sizeof...(Ts) > 1,
         "Closure should have argument and return type");
 
-      /// Closure info table initializer
-      struct info_table_initializer
-      {
-        /// static closure info
-        static const closure_info_table info_table;
-      };
+      /// specifier
+      static constexpr auto specifier =
+        normalize_specifier(type_c<closure<Ts...>>);
 
       /// Ctor
       Function() noexcept
@@ -279,7 +272,7 @@ namespace TORI_NS::detail {
       using return_type =
         return_type_checker<argument_proxy_t<sizeof...(Ts) - 1>>;
 
-      /// Get N'th argument
+      /// get N'th argument thunk
       template <uint64_t N>
       auto arg() const noexcept
       {
@@ -289,7 +282,7 @@ namespace TORI_NS::detail {
         return static_object_cast<To>(obj);
       }
 
-      /// Evaluate N'th argument and take result
+      /// evaluate N'th argument and take result
       template <uint64_t N>
       auto eval_arg() const
       {
@@ -307,6 +300,13 @@ namespace TORI_NS::detail {
       using base::code;
       using base::m_arity;
       using base::m_args;
+
+      /// Closure info table initializer
+      struct info_table_initializer
+      {
+        /// static closure info
+        static const closure_info_table info_table;
+      };
 
       /// check signature of code()
       void check_code()

--- a/include/tori/core/specifiers.hpp
+++ b/include/tori/core/specifiers.hpp
@@ -30,19 +30,15 @@ namespace TORI_NS::detail {
   // ------------------------------------------
   // proxy types (forward decl)
 
-  /// proxy type of arbitary closure type
   template <class... Ts>
   struct ClosureProxy;
 
-  /// proxy type for arbitary closure type argument in Function
   template <class... Ts>
   struct ClosureArgumentProxy;
 
-  /// proy type of instance of type variable
   template <class Tag>
   struct VarValueProxy;
 
-  /// proxy type of named objec type
   template <class T>
   struct ObjectProxy;
 

--- a/include/tori/core/static_typing.hpp
+++ b/include/tori/core/static_typing.hpp
@@ -4,13 +4,13 @@
 #pragma once
 
 #include "../config/config.hpp"
-#include "terms.hpp"
-#include "types.hpp"
-
 #include "meta_type.hpp"
 #include "meta_tuple.hpp"
 #include "meta_set.hpp"
 #include "meta_pair.hpp"
+
+#include "terms.hpp"
+#include "types.hpp"
 
 namespace TORI_NS::detail {
 

--- a/include/tori/core/type_gen.hpp
+++ b/include/tori/core/type_gen.hpp
@@ -51,7 +51,7 @@ namespace TORI_NS::detail {
       closure_term_export(make_tm_closure(get_term<Ts>()...));
   };
 
-  /// proxy type of argument closure type in Function
+  /// proxy type of argument closure type
   template <class... Ts>
   struct ClosureArgumentProxy : Object
   {

--- a/include/tori/core/type_gen.hpp
+++ b/include/tori/core/type_gen.hpp
@@ -6,6 +6,7 @@
 #include "../config/config.hpp"
 #include "box.hpp"
 #include "type_value.hpp"
+#include "specifiers.hpp"
 
 #include <cstring>
 #include <string>
@@ -38,47 +39,37 @@ TORI_DECL_TYPE(Object)
 
 namespace TORI_NS::detail {
 
-  namespace interface {
-
-    /// proxy type of closure
-    template <class... Ts>
-    struct closure : Object
-    {
-      /// term
-      static constexpr auto term = make_tm_closure(get_term<Ts>()...);
-    };
-
-    /// Type variable value
-    template <class Tag>
-    struct forall : Object
-    {
-      // term
-      static constexpr auto term = type_c<tm_varvalue<Tag>>;
-    };
-
-  } // namespace interface
-
   // ------------------------------------------
-  // utility
+  // proxy types
 
-  template <class... Ts, class T>
-  constexpr auto append(meta_type<T>, meta_type<closure<Ts...>>)
+  /// proxy type of arbitary closure type
+  template <class... Ts>
+  struct ClosureProxy : Object
   {
-    return type_c<closure<Ts..., T>>;
-  }
+    /// term
+    static constexpr auto term =
+      closure_term_export(make_tm_closure(get_term<Ts>()...));
+  };
 
+  /// proxy type of argument closure type in Function
+  template <class... Ts>
+  struct ClosureArgumentProxy : Object
+  {
+    /// term
+    static constexpr auto term = make_tm_closure(get_term<Ts>()...);
+  };
+
+  /// proy type of instance of type variable
   template <class Tag>
-  constexpr auto make_forall(meta_type<Tag>)
+  struct VarValueProxy : Object
   {
-    return type_c<forall<Tag>>;
-  }
+    /// term
+    static constexpr auto term = type_c<tm_varvalue<Tag>>;
+  };
 
-  // ------------------------------------------
-  // expected
-
-  /// expected
+  /// proxy type of named objec type
   template <class T>
-  struct expected : Object
+  struct ObjectProxy : Object
   {
     // term
     static constexpr auto term = get_term<T>();
@@ -209,7 +200,10 @@ namespace TORI_NS::detail {
     template <class T>
     [[nodiscard]] object_ptr<const Type> object_type()
     {
-      return object_type_impl(get_term<T>());
+      constexpr auto spec = normalize_specifier(type_c<T>);
+      constexpr auto tp = get_proxy_type(spec);
+      // get term through proxy type
+      return object_type_impl(get_term(tp));
     }
 
   } // namespace interface
@@ -221,7 +215,7 @@ namespace TORI_NS::detail {
   template <class T, class... Ts>
   constexpr auto guess_object_type_closure(
     meta_type<T> type,
-    meta_type<closure<Ts...>> result)
+    meta_type<ClosureProxy<Ts...>> result)
   {
     if constexpr (is_arrow_type(type)) {
       return guess_object_type_closure(
@@ -232,18 +226,18 @@ namespace TORI_NS::detail {
   }
 
   /// Guess C++ type of a type.
-  /// Unknown types will be converted into `Object` equivalents.
+  /// Unknown types will be converted into proxy.
   template <class T>
   constexpr auto guess_object_type(meta_type<T> type)
   {
     if constexpr (is_arrow_type(type)) {
-      return guess_object_type_closure(type, type_c<closure<>>);
+      return guess_object_type_closure(type, type_c<ClosureProxy<>>);
     } else if constexpr (is_value_type(type)) {
-      return type.tag();
-    } else if constexpr (is_var_type(type)) {
-      return type_c<Object>;
+      using tag = typename decltype(type.tag())::type;
+      return get_object_type(type_c<ObjectProxy<tag>>);
     } else if constexpr (is_varvalue_type(type)) {
-      return make_forall(type.tag());
+      using tag = typename decltype(type.tag())::type;
+      return type_c<VarValueProxy<tag>>;
     } else
       static_assert(false_v<T>, "Invalid type");
   }

--- a/include/tori/core/type_gen.hpp
+++ b/include/tori/core/type_gen.hpp
@@ -235,7 +235,7 @@ namespace TORI_NS::detail {
     } else if constexpr (is_value_type(type)) {
       using tag = typename decltype(type.tag())::type;
       return get_object_type(type_c<ObjectProxy<tag>>);
-    } else if constexpr (is_varvalue_type(type)) {
+    } else if constexpr (is_varvalue_type(type) || is_var_type(type)) {
       using tag = typename decltype(type.tag())::type;
       return type_c<VarValueProxy<tag>>;
     } else

--- a/include/tori/core/value_cast.hpp
+++ b/include/tori/core/value_cast.hpp
@@ -70,10 +70,10 @@ namespace TORI_NS::detail {
     [[nodiscard]] object_ptr<propagate_const_t<T, U>>
       value_cast(const object_ptr<U>& obj)
     {
-      static_assert(!is_tm_closure(get_term<T>()), "T is not value type");
-
       if (likely(obj && has_type<T>(obj))) {
-        return static_object_cast<propagate_const_t<T, U>>(obj);
+        using To = typename decltype(
+          get_object_type(normalize_specifier(type_c<T>)))::type;
+        return static_object_cast<propagate_const_t<To, U>>(obj);
       }
       throw bad_value_cast(obj ? get_type(obj) : nullptr, object_type<T>());
     }
@@ -86,10 +86,10 @@ namespace TORI_NS::detail {
     [[nodiscard]] object_ptr<propagate_const_t<T, U>>
       value_cast(object_ptr<U>&& obj)
     {
-      static_assert(!is_tm_closure(get_term<T>()), "T is not value type");
-
       if (likely(obj && has_type<T>(obj))) {
-        return static_object_cast<propagate_const_t<T, U>>(std::move(obj));
+        using To = typename decltype(
+          get_object_type(normalize_specifier(type_c<T>)))::type;
+        return static_object_cast<propagate_const_t<To, U>>(std::move(obj));
       }
       throw bad_value_cast(obj ? get_type(obj) : nullptr, object_type<T>());
     }
@@ -102,10 +102,10 @@ namespace TORI_NS::detail {
     [[nodiscard]] object_ptr<propagate_const_t<T, U>>
       value_cast_if(const object_ptr<U>& obj) noexcept
     {
-      static_assert(!is_tm_closure(get_term<T>()), "T is not value type");
-
       if (likely(obj && has_type<T>(obj))) {
-        return static_object_cast<propagate_const_t<T, U>>(obj);
+        using To = typename decltype(
+          get_object_type(normalize_specifier(type_c<T>)))::type;
+        return static_object_cast<propagate_const_t<To, U>>(obj);
       }
       return nullptr;
     }
@@ -118,10 +118,10 @@ namespace TORI_NS::detail {
     [[nodiscard]] object_ptr<propagate_const_t<T, U>>
       value_cast_if(object_ptr<U>&& obj) noexcept
     {
-      static_assert(!is_tm_closure(get_term<T>()), "T is not value type");
-
       if (likely(obj && has_type<T>(obj))) {
-        return static_object_cast<propagate_const_t<T, U>>(std::move(obj));
+        using To = typename decltype(
+          get_object_type(normalize_specifier(type_c<T>)))::type;
+        return static_object_cast<propagate_const_t<To, U>>(std::move(obj));
       }
       return nullptr;
     }

--- a/test/core/function.cpp
+++ b/test/core/function.cpp
@@ -79,10 +79,31 @@ TEST_CASE("polymorphic function test")
     {
       return_type code() const
       {
+        static_assert(
+          type_c<argument_proxy_t<1>> ==
+          type_c<
+            const ClosureArgumentProxy<ObjectProxy<Int>, VarValueProxy<X>>>);
         return arg<1>() << arg<0>();
       }
     };
-    auto f4 = make_object<F>();
+    auto f = make_object<F>();
+  }
+
+  SECTION("polymorphic closure declaration")
+  {
+    class X;
+    struct F : Function<F, Int, closure<Int, X>, X>
+    {
+      return_type code() const
+      {
+        static_assert(
+          type_c<argument_proxy_t<1>> ==
+          type_c<
+            const ClosureArgumentProxy<ObjectProxy<Int>, VarValueProxy<X>>>);
+        return arg<1>() << arg<0>();
+      }
+    };
+    auto f = make_object<F>();
   }
 
   SECTION("polymorphic return type")
@@ -92,6 +113,11 @@ TEST_CASE("polymorphic function test")
     {
       return_type code() const
       {
+        static_assert(
+          type_c<argument_proxy_t<1>> == type_c<argument_proxy_t<2>>);
+        static_assert(
+          type_c<argument_proxy_t<1>> == type_c<const VarValueProxy<X>>);
+
         if (*eval_arg<0>())
           return arg<1>();
         else

--- a/test/core/function.cpp
+++ b/test/core/function.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 
 using namespace tori;
+using namespace tori::detail;
 
 TEST_CASE("simple function test")
 {
@@ -14,6 +15,8 @@ TEST_CASE("simple function test")
     {
       return_type code() const
       {
+        static_assert(
+          type_c<argument_proxy_t<0>> == type_c<const ObjectProxy<Int>>);
         return arg<0>();
         return eval_arg<0>();
         return eval(arg<0>());
@@ -32,6 +35,9 @@ TEST_CASE("higher order function test")
     {
       return_type code() const
       {
+        static_assert(
+          type_c<argument_proxy_t<0>> ==
+          type_c<const ClosureArgumentProxy<ObjectProxy<Int>, ObjectProxy<Int>>>);
         return arg<0>();
         return eval_arg<0>();
         return eval(arg<0>());

--- a/test/core/static_typing.cpp
+++ b/test/core/static_typing.cpp
@@ -334,9 +334,9 @@ void test_genpoly()
   {
     // Double -> Var<X> -> Var<X>
     constexpr auto term =
-      remove_varvalue(type_c<tm_closure<
-                        tm_closure<tm_value<double>, tm_varvalue<class X>>,
-                        tm_varvalue<class X>>>);
+      closure_term_export(type_c<tm_closure<
+                            tm_closure<tm_value<double>, tm_varvalue<class X>>,
+                            tm_varvalue<class X>>>);
 
     // Double -> Var[0] -> Var[0]
     constexpr auto gterm = type_c<tm_closure<
@@ -351,24 +351,25 @@ void test_assume_object_type()
 {
   {
     // value<T> -> T
-    static_assert(guess_object_type(type_c<value<int>>) == type_c<int>);
+    static_assert(guess_object_type(type_c<value<Int>>) == type_c<Int>);
   }
   {
-    // var<class T> -> Object
+    // varvalue<T> -> VarValurProxy<T>
     static_assert(
-      guess_object_type(type_c<var<class Tag>>) == type_c<Object>);
+      guess_object_type(type_c<varvalue<class Tag>>) ==
+      type_c<VarValueProxy<class Tag>>);
   }
   {
     // arrow<S, T> -> closure<S, T>
     static_assert(
       guess_object_type(type_c<arrow<value<Double>, value<Int>>>) ==
-      type_c<closure<Double, Int>>);
+      type_c<ClosureProxy<Double, Int>>);
 
     // arrow<S, arrow<T, U>> -> closure<S, T, U>
     static_assert(
       guess_object_type(
         type_c<arrow<value<Int>, arrow<value<Double>, value<Int>>>>) ==
-      type_c<closure<Int, Double, Int>>);
+      type_c<ClosureProxy<Int, Double, Int>>);
 
     // arrow<arrow<Double, Int>, arrow<Double, Int>> -> closure<closure<Double,
     // Int>, Double, Int>
@@ -376,6 +377,6 @@ void test_assume_object_type()
       guess_object_type(type_c<arrow<
                           arrow<value<Double>, value<Int>>,
                           arrow<value<Double>, value<Int>>>>) ==
-      type_c<closure<closure<Double, Int>, Double, Int>>);
+      type_c<ClosureProxy<ClosureProxy<Double, Int>, Double, Int>>);
   }
 }

--- a/test/core/static_typing.cpp
+++ b/test/core/static_typing.cpp
@@ -360,6 +360,12 @@ void test_assume_object_type()
       type_c<VarValueProxy<class Tag>>);
   }
   {
+    // var<T> -> VarValurProxy<T>
+    static_assert(
+      guess_object_type(type_c<var<class Tag>>) ==
+      type_c<VarValueProxy<class Tag>>);
+  }
+  {
     // arrow<S, T> -> closure<S, T>
     static_assert(
       guess_object_type(type_c<arrow<value<Double>, value<Int>>>) ==


### PR DESCRIPTION
Add new abstruction layer to hande arguments in template API.

Currently, `closure<Ts...>` and `forall<Tag>` are simply wrappers of `Object`.
But since I added support for incomplete type parameters to specify polymorphic type variables, now I need to convert these types to `forall<T>` before extracting `term`, and properly convert them to proxy types when accessed by `arg<N>()`.

To implement these features in a clear way, I decided to add new abstruction layer called `specifier`.  
All types given to template arguments will be once "lifted" into specifiers. Then those specifiers are converted into `*Proxy` types which has corresponding `term` variable to be extracted.

Another good reason to add specifiers is now `closure` and `forall` are no longer heap object even though they don't have names starting from capital letters.