### PR TITLE
Make Fix normal function

### DIFF
--- a/example/fibonacci.cpp
+++ b/example/fibonacci.cpp
@@ -4,8 +4,10 @@
 // just for this example...
 using namespace tori;
 
-struct fib : Function<fib, Int, Int> {
-  struct impl : Function<impl, closure<Int, Int>, Int, Int> {
+struct Fib : Function<Fib, Int, Int>
+{
+  struct Impl : Function<Impl, closure<Int, Int>, Int, Int>
+  {
     return_type code() const
     {
       auto fib = arg<0>();
@@ -19,22 +21,23 @@ struct fib : Function<fib, Int, Int> {
       return new Int(*value_cast<Int>(l) + *value_cast<Int>(r));
     }
   };
+
   return_type code() const
   {
     static const auto fix = make_object<Fix>();
-    return fix << new impl() << arg<0>();
+    static const auto impl = make_object<Impl>();
+    return fix << impl << arg<0>();
   }
 };
 
 int main()
 {
-  auto app = make_object<fib>() << new Int(10);
+  auto app = make_object<Fib>() << new Int(10);
   try {
     check_type<Int>(app);
     auto result = eval(app);
     std::cout << *value_cast<Int>(result) << std::endl;
   } catch (std::exception& e) {
-    // blah blah
     std::cout << e.what() << std::endl;
   }
 }

--- a/include/tori/core.hpp
+++ b/include/tori/core.hpp
@@ -15,9 +15,9 @@
 #include "core/exception.hpp"
 #include "core/type_error.hpp"
 #include "core/value_cast.hpp"
-#include "core/fix.hpp"
 #include "core/apply.hpp"
 #include "core/eval.hpp"
+#include "core/fix.hpp"
 
 // compatibility check
 #include "config/compatibility.hpp"

--- a/include/tori/core/apply.hpp
+++ b/include/tori/core/apply.hpp
@@ -6,7 +6,6 @@
 #include "../config/config.hpp"
 #include "box.hpp"
 #include "type_gen.hpp"
-#include "fix.hpp"
 
 namespace TORI_NS::detail {
 

--- a/include/tori/core/dynamic_typing.hpp
+++ b/include/tori/core/dynamic_typing.hpp
@@ -397,20 +397,12 @@ namespace TORI_NS::detail {
   {
     // Apply
     if (auto apply = value_cast_if<const ApplyR>(obj)) {
-      if (auto fix = value_cast_if<const Fix>(apply->app())) {
-        auto _t1 = type_of_func_impl(apply->arg());
-        auto _t = genvar();
-        auto c = std::vector {Constr {_t1, new Type(ArrowType {_t, _t})}};
-        auto s = unify(std::move(c), obj);
-        return subst_type_all(s, _t); // FIXME should use genvar() instead of _t?
-      } else {
-        auto _t1 = type_of_func_impl(apply->app());
-        auto _t2 = type_of_func_impl(apply->arg());
-        auto _t = genvar();
-        auto c = std::vector {Constr {_t1, new Type(ArrowType {_t2, _t})}};
-        auto s = unify(std::move(c), obj);
-        return subst_type_all(s, _t);
-      }
+      auto _t1 = type_of_func_impl(apply->app());
+      auto _t2 = type_of_func_impl(apply->arg());
+      auto _t = genvar();
+      auto c = std::vector {Constr {_t1, new Type(ArrowType {_t2, _t})}};
+      auto s = unify(std::move(c), obj);
+      return subst_type_all(s, _t);
     }
     // value -> value
     if (has_value_type(obj))

--- a/include/tori/core/function.hpp
+++ b/include/tori/core/function.hpp
@@ -7,7 +7,6 @@
 #include "static_typing.hpp"
 #include "dynamic_typing.hpp"
 
-#include "fix.hpp"
 #include "apply.hpp"
 #include "string.hpp"
 

--- a/include/tori/core/terms.hpp
+++ b/include/tori/core/terms.hpp
@@ -44,12 +44,6 @@ namespace TORI_NS::detail {
   {
   };
 
-  /// tm_fix
-  template <class Tag>
-  struct tm_fix
-  {
-  };
-
   // ------------------------------------------
   // has_term
 
@@ -106,16 +100,6 @@ namespace TORI_NS::detail {
   struct meta_type<tm_value<Tag>>
   {
     using type = tm_value<Tag>;
-    constexpr auto tag() const
-    {
-      return type_c<Tag>;
-    }
-  };
-
-  template <class Tag>
-  struct meta_type<tm_fix<Tag>>
-  {
-    using type = tm_fix<Tag>;
     constexpr auto tag() const
     {
       return type_c<Tag>;
@@ -296,35 +280,6 @@ namespace TORI_NS::detail {
   constexpr auto has_tm_varvalue()
   {
     return is_varvalue(get_term<T>());
-  }
-
-  // ------------------------------------------
-  // is_tm_fix
-
-  template <class T>
-  struct is_tm_fix_impl
-  {
-    static constexpr auto value = false_c;
-  };
-
-  template <class Tag>
-  struct is_tm_fix_impl<tm_fix<Tag>>
-  {
-    static constexpr auto value = true_c;
-  };
-
-  // is_tm_fix
-  template <class T>
-  constexpr auto is_tm_fix(meta_type<T>)
-  {
-    return is_tm_fix_impl<T>::value;
-  }
-
-  // has_tm_fix
-  template <class T>
-  constexpr auto has_tm_fix()
-  {
-    return is_tm_fix(get_term<T>());
   }
 
   // ------------------------------------------

--- a/include/tori/core/type_gen.hpp
+++ b/include/tori/core/type_gen.hpp
@@ -187,8 +187,6 @@ namespace TORI_NS::detail {
       return var_type_address(term);
     } else if constexpr (is_tm_varvalue(term)) {
       return var_type_address(term);
-    } else if constexpr (is_tm_fix(term)) {
-      return value_type_address(term);
     } else {
       static_assert(false_v<T>);
     }

--- a/test/core/static_typing.cpp
+++ b/test/core/static_typing.cpp
@@ -296,7 +296,7 @@ void test_type_of()
   {
     // fix ((int -> bool) -> (int -> bool)) = int -> bool
     constexpr auto ff = type_c<tm_apply<
-      tm_fix<Fix>,
+      tm_closure<tm_closure<tm_var<class X>, tm_var<class X>>, tm_var<class X>>,
       tm_closure<
         tm_closure<tm_value<int>, tm_value<bool>>,
         tm_value<int>,


### PR DESCRIPTION
Since we can create closure which has type `(a->a)->a`, I can make `Fix` just a normal function.  
Implementing `code` of `Fix` still requires some "magic" so I keep it in core header files. 

Implementation notes:
In graph reduction languages, fixed-point combinator can be implemented by returning self-referencing apply node `x = f x`. But in practice, such implementation creates additional indirect circular references not just apply node retuend by "fix" function. Since this library uses reference-counted GC, dealing with indirect circular reference is real pain. So I slightly changed strategy of implementation here; instead of returning self-referencing apply node, "Fix" retuens self-referencing ***partial application***. This only generates single self-referencing circular reference which is relatively easy to deal with.